### PR TITLE
Enhance script for custom nameservers and clearing

### DIFF
--- a/dnsch.sh
+++ b/dnsch.sh
@@ -11,47 +11,60 @@ if [[ ! -e /etc/resolv.conf.bak ]]; then
     cp /etc/resolv.conf /etc/resolv.conf.bak
 fi
 
-# Verify that argument is provided
-if [[ -z $1 ]]; then
-    echo "Usage: $0 {g|sh|ag|cf|403|bg|rd|el|clear}"
+# Function to print usage instructions
+usage() {
+    echo "Usage: $0 {g|sh|ag|cf|403|bg|rd|el} [-c|--clear] [-s|--set]"
     exit 1
+}
+
+# Verify the number of arguments provided
+if [[ $# -lt 1 ]]; then
+    usage
 fi
 
-# Define the nameservers to add based on input argument
-case $1 in
-    g)
-        nameservers=("nameserver 8.8.8.8" "nameserver 8.8.4.4")
-        ;;
-    sh)
-        nameservers=("nameserver 178.22.122.100" "nameserver 185.51.200.2")
-        ;;
-    ag)
-        nameservers=("nameserver 176.103.130.130" "nameserver 176.103.130.131")
-        ;;
-    cf)
-        nameservers=("nameserver 1.1.1.1" "nameserver 1.0.0.1")
-        ;;
-    403)
-        nameservers=("nameserver 10.202.10.202" "nameserver 10.202.10.102")
-        ;;
-    bg)
-        nameservers=("nameserver 185.55.226.26" "nameserver 185.55.225.25")
-        ;;
-    rd)
-        nameservers=("nameserver 10.202.10.10" "nameserver 10.202.10.11")
-        ;;
-    el)
-        nameservers=("nameserver 78.157.42.100" "nameserver 78.157.42.101")
-        ;;
-    clear)
-        nameservers=()
-        ;;
-    *)
-        echo "Invalid option: $1"
-        echo "Usage: $0 {g|sh|ag|cf|403|bg|rd|el|clear}"
-        exit 1
-        ;;
-esac
+# Parse the arguments
+if [[ $1 == "-s" || $1 == "--set" ]]; then
+    # Check if exactly two IP addresses are provided
+    if [[ $# -ne 3 ]]; then
+        usage
+    fi
+    # Set the nameservers based on provided IP addresses
+    nameservers=("nameserver $2" "nameserver $3")
+elif [[ $1 == "-c" || $1 == "--clear" ]]; then
+    nameservers=()
+else
+    # Define the nameservers to add based on input argument
+    case $1 in
+        g)
+            nameservers=("nameserver 8.8.8.8" "nameserver 8.8.4.4")
+            ;;
+        sh)
+            nameservers=("nameserver 178.22.122.100" "nameserver 185.51.200.2")
+            ;;
+        ag)
+            nameservers=("nameserver 176.103.130.130" "nameserver 176.103.130.131")
+            ;;
+        cf)
+            nameservers=("nameserver 1.1.1.1" "nameserver 1.0.0.1")
+            ;;
+        403)
+            nameservers=("nameserver 10.202.10.202" "nameserver 10.202.10.102")
+            ;;
+        bg)
+            nameservers=("nameserver 185.55.226.26" "nameserver 185.55.225.25")
+            ;;
+        rd)
+            nameservers=("nameserver 10.202.10.10" "nameserver 10.202.10.11")
+            ;;
+        el)
+            nameservers=("nameserver 78.157.42.100" "nameserver 78.157.42.101")
+            ;;
+        *)
+            echo "Invalid option: $1"
+            usage
+            ;;
+    esac
+fi
 
 # Remove all existing nameservers and add new ones atomically
 # This avoids potential issues with an empty or partial file


### PR DESCRIPTION
This commit introduces **enhancements** to the script, allowing users to **set custom nameservers** using the -s or --set flags, and **clear existing configurations** with the -c or --clear flag.